### PR TITLE
Fix: Call to a member function getName() on null

### DIFF
--- a/src/Models/RequestLog.php
+++ b/src/Models/RequestLog.php
@@ -102,7 +102,7 @@ class RequestLog extends Model implements RequestLoggerInterface
         $model->session = $request->hasSession() ? $request->session()->getId() : null;
         $model->middleware = array_values(optional($request->route())->gatherMiddleware() ?? []);
         $model->method = $request->getMethod();
-        $model->route = optional($request->route())->getName() ?? optional($request->route())->uri(), // Note that $request->route()->uri() does not replace the placeholders while $request->getRequestUri() replaces the placeholders
+        $model->route = optional($request->route())->getName() ?? optional($request->route())->uri(); // Note that $request->route()->uri() does not replace the placeholders while $request->getRequestUri() replaces the placeholders
         $model->path = $request->path();
         $model->status = $response->getStatusCode();
         $model->headers = $this->getFiltered($request->headers->all()) ?: null;

--- a/src/Models/RequestLog.php
+++ b/src/Models/RequestLog.php
@@ -102,7 +102,7 @@ class RequestLog extends Model implements RequestLoggerInterface
         $model->session = $request->hasSession() ? $request->session()->getId() : null;
         $model->middleware = array_values(optional($request->route())->gatherMiddleware() ?? []);
         $model->method = $request->getMethod();
-        $model->route = $request->route()->getName();
+        $model->route = $request->route()?->getName();
         $model->path = $request->path();
         $model->status = $response->getStatusCode();
         $model->headers = $this->getFiltered($request->headers->all()) ?: null;

--- a/src/Models/RequestLog.php
+++ b/src/Models/RequestLog.php
@@ -102,7 +102,7 @@ class RequestLog extends Model implements RequestLoggerInterface
         $model->session = $request->hasSession() ? $request->session()->getId() : null;
         $model->middleware = array_values(optional($request->route())->gatherMiddleware() ?? []);
         $model->method = $request->getMethod();
-        $model->route = $request->route()?->getName();
+        $model->route = optional($request->route())->getName() ?? optional($request->route())->uri(), // Note that $request->route()->uri() does not replace the placeholders while $request->getRequestUri() replaces the placeholders
         $model->path = $request->path();
         $model->status = $response->getStatusCode();
         $model->headers = $this->getFiltered($request->headers->all()) ?: null;


### PR DESCRIPTION
This fix the `Call to a member function getName() on null` error when trying to access  the supposedly`NotFoundHttpException` route

![Screen Shot 2021-11-15 at 6 08 24 PM](https://user-images.githubusercontent.com/8844488/141762930-a52514ca-5b94-41da-9e28-07e6809968e7.png)

Steps to reproduce:
1. tested in `api.php` route file.
2. try the endpoint `http://{endpoint}/api/supposedly-404-page`