### PR TITLE
add ability to have more headers

### DIFF
--- a/config/request-logger.php
+++ b/config/request-logger.php
@@ -22,7 +22,17 @@ return [
     | headers using the specified key.
     |
     */
-    'header' => env('REQUEST_LOGGER_HEADER', 'Request-Id'), // null means disabled
+    'headers' => [
+        'header' => [
+            'name' => env('REQUEST_LOGGER_HEADER', 'Request-Id'), // null means disabled,
+            'value' => fn() => isset($request)?$request->getUniqueId():null,
+        ],
+        'version' => [
+            'name' => env('REQUEST_LOGGER_VERSION_HEADER', 'App-Version'),
+            'value' => fn() => gethostname(),
+        ]
+    ],
+
 
     /*
     |--------------------------------------------------------------------------

--- a/config/request-logger.php
+++ b/config/request-logger.php
@@ -25,11 +25,11 @@ return [
     'headers' => [
         'header' => [
             'name' => env('REQUEST_LOGGER_HEADER', 'Request-Id'), // null means disabled,
-            'value' => fn() => isset($request)?$request->getUniqueId():null,
+            'value' => fn () => isset($request) ? $request->getUniqueId() : null,
         ],
         'version' => [
             'name' => env('REQUEST_LOGGER_VERSION_HEADER', 'App-Version'),
-            'value' => fn() => gethostname(),
+            'value' => fn () => gethostname(),
         ]
     ],
 

--- a/config/request-logger.php
+++ b/config/request-logger.php
@@ -30,7 +30,7 @@ return [
         'version' => [
             'name' => env('REQUEST_LOGGER_VERSION_HEADER', 'App-Version'),
             'value' => fn () => gethostname(),
-        ]
+        ],
     ],
 
 

--- a/src/Middleware/LogRequestMiddleware.php
+++ b/src/Middleware/LogRequestMiddleware.php
@@ -4,6 +4,7 @@ namespace Bilfeldt\RequestLogger\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 
 class LogRequestMiddleware
@@ -29,8 +30,12 @@ class LogRequestMiddleware
 
         $response = $next($request);
 
-        if ($header = config('request-logger.header')) {
-            $response->headers->set($header, $requestId, true); // This is available on all Response types whereas $request->header() is only available in \Illuminate\Http\Response
+        // Headers are available to Response types whereas $request->header() is only available in \Illuminate\Http\Response
+        foreach (config('request-logger.headers') as $header) {
+            if ($header_name = Arr::get($header, 'name')) {
+                // key 'value' can be a \Closure or any other type of value
+                $response->headers->set($header_name, value(Arr::get($header, 'value')), true);
+            }
         }
 
         return $response;

--- a/tests/Unit/LogRequestMiddlewareTest.php
+++ b/tests/Unit/LogRequestMiddlewareTest.php
@@ -48,7 +48,7 @@ class LogRequestMiddlewareTest extends TestCase
         $this->assertFalse($response1->headers->has('test-header'));
 
         Config::set('request-logger.headers.header.name', 'test-header');
-        Config::set('request-logger.headers.header.value', fn() => isset($request)?$request->getUniqueId():null);
+        Config::set('request-logger.headers.header.value', fn () => isset($request) ? $request->getUniqueId() : null);
 
         $response2 = (new LogRequestMiddleware())->handle($request, function ($request) {
             return new Response();

--- a/tests/Unit/LogRequestMiddlewareTest.php
+++ b/tests/Unit/LogRequestMiddlewareTest.php
@@ -59,7 +59,8 @@ class LogRequestMiddlewareTest extends TestCase
         $this->assertEquals($request->getUniqueId(), $response2->headers->get('test-header'));
     }
 
-    public function test_has_app_version_header() {
+    public function test_has_app_version_header()
+    {
         $request = new Request();
 
         $response1 = (new LogRequestMiddleware())->handle($request, function ($request) {


### PR DESCRIPTION
Header values can be closures. implement an App-Version sample header

# Description

This comes from an idea to add a hostname into the header to monitor the responding server in case of load balancing.
I restructured the configuration array a bit, so now it is possible to have as many headers as you want and you can define the header value as a closure if you want to.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# Checklist

- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


greetings, J
