### PR TITLE
Exclude 'api_token' from logs per default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-request-logger` will be documented in this file.
 
-## 1.0.0 - 202X-XX-XX
+## v1.0.2 - 2022-01-11
+
+- Exclude the parameter api_token per default from all logs (added to config) #17
+
+## v1.0.1 - 2021-11-15
+
+- Fix issue when route is undefined: By @woenel in #15
+
+## 1.0.0 - 2021-11-12
 
 - initial release

--- a/config/request-logger.php
+++ b/config/request-logger.php
@@ -96,6 +96,7 @@ return [
         'password',
         'password_confirm',
         'apikey',
+        'api_token',
         'Authorization',
         'filter.search',
     ],


### PR DESCRIPTION
Exclude the parameter `api_token` per default from all logs (added to config)