### PR TITLE
Server Error bug when path long

### DIFF
--- a/database/migrations/create_request_logs_table.php.stub
+++ b/database/migrations/create_request_logs_table.php.stub
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->unsignedSmallInteger('status')->nullable();
             $table->string('method')->nullable();
             $table->string('route')->nullable(); // Not all routes needs to have a name
-            $table->string('path')->nullable();
+            $table->text('path')->nullable();
             $table->json('headers')->nullable();
             $table->json('payload')->nullable();
             $table->json('response_headers')->nullable();


### PR DESCRIPTION
This fixes the SQL problem `SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'path'` when user attempt to access very long URL path or accessed by some vulnerability scanner (e.g. Qualys PCI DSS scanner).

Steps to reproduce:
1. Go to your app URL.
2. Enter very long path that exceeds 255 characters.
3. An SQL error will appear on logs and page will return 5xx error instead of 404.

Example error log (executed by Qualys VAPT)
![SQL 1406 Error](https://i.ibb.co/gMcMvCh/Screen-Shot-2022-01-25-at-5-54-00-PM.png)
