### PR TITLE
Allowing Laravel 10 with PHP 8.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2]
+        php: [8.2, 8.1]
         laravel: [10.*]
         dependency-version: [prefer-stable]
         include:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Zero configuration logging of Requests and Responses to database or custom drive
 | Version | Laravel     | PHP                     |
 |---------|-------------|-------------------------|
 | 1.*     | 8.* \| 9.*  | 7.4.* \| 8.0.* \| 8.1.* |
-| 2.*     | 10.*        | 8.2.*                   |
+| 2.*     | 10.*        | 8.1.* \ |8.2.*          |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Zero configuration logging of Requests and Responses to database or custom drive
 | Version | Laravel     | PHP                     |
 |---------|-------------|-------------------------|
 | 1.*     | 8.* \| 9.*  | 7.4.* \| 8.0.* \| 8.1.* |
-| 2.*     | 10.*        | 8.1.* \ |8.2.*          |
+| 2.*     | 10.*        | 8.1.* \| 8.2.*          |
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.1 || ^8.2",
+        "php": "~8.1.0 || ~8.2.0",
         "spatie/laravel-package-tools": "^1.4.3",
         "illuminate/contracts": "^10.0",
         "ext-json": "*"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "~8.2.0",
+        "php": "~8.1.0",
         "spatie/laravel-package-tools": "^1.4.3",
         "illuminate/contracts": "^10.0",
         "ext-json": "*"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "~8.1.0",
+        "php": "^8.1 || ^8.2",
         "spatie/laravel-package-tools": "^1.4.3",
         "illuminate/contracts": "^10.0",
         "ext-json": "*"


### PR DESCRIPTION
# Description

This changes allow the usage of package using Laravel 10 with PHP 8.1

## Does this close any currently open issues?

The issue: [Not possible to use the package in Laravel 10 with PHP 8.1?](https://github.com/bilfeldt/laravel-route-statistics/issues/21)

Fixes #

Adding support for PHP 8.1 with Laravel 10

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Any relevant logs, error output, etc?

Installing packages with my dev branch:
![image](https://github.com/bilfeldt/laravel-request-logger/assets/60560085/b6c5003f-7518-4378-8942-7a68cc94c4b3)

...
> Notice: This PR must be accepted and released before of the "laravel-route-statistics" package.


# Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
