### PR TITLE
Add CorrelationIdMiddleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ No breaking changes. The only changes are to the development dependencies used f
 
 ## Changes
 
+### 2.2.0 - 2023-08-29
+
+- Add middleware for adding 'Correlation-ID' header to responses
+
 ### 2.1.0 - 2023-07-24
 
 - Add support for PHP 8.1

--- a/src/Middleware/CorrelationIdMiddleware.php
+++ b/src/Middleware/CorrelationIdMiddleware.php
@@ -16,10 +16,20 @@ class CorrelationIdMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
+        $correlationId = $this->getCorrelationId($request);
+
+        $request->headers->set('Correlation-ID', $correlationId, true);
+
         $response = $next($request);
 
-        $response->headers->set('Correlation-ID', $request->getUniqueId(), true); // This is available on all Response types whereas $request->header() is only available in \Illuminate\Http\Response
+        $response->headers->set('Correlation-ID', $correlationId, true); // This is available on all Response types whereas $response->header() is only available in \Illuminate\Http\Response
 
         return $response;
     }
+
+    private function getCorrelationId(Request $request): string
+    {
+        return $request->getUniqueId();
+    }
+
 }

--- a/src/Middleware/CorrelationIdMiddleware.php
+++ b/src/Middleware/CorrelationIdMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bilfeldt\RequestLogger\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class CorrelationIdMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        $response->headers->set('Correlation-ID', $request->getUniqueId(), true); // This is available on all Response types whereas $request->header() is only available in \Illuminate\Http\Response
+
+        return $response;
+    }
+}

--- a/src/Middleware/CorrelationIdMiddleware.php
+++ b/src/Middleware/CorrelationIdMiddleware.php
@@ -31,5 +31,4 @@ class CorrelationIdMiddleware
     {
         return $request->getUniqueId();
     }
-
 }

--- a/src/Middleware/LogRequestMiddleware.php
+++ b/src/Middleware/LogRequestMiddleware.php
@@ -30,7 +30,7 @@ class LogRequestMiddleware
         $response = $next($request);
 
         if ($header = config('request-logger.header')) {
-            $response->headers->set($header, $requestId, true); // This is available on all Response types whereas $request->header() is only available in \Illuminate\Http\Response
+            $response->headers->set($header, $requestId, true); // This is available on all Response types whereas $response->header() is only available in \Illuminate\Http\Response
         }
 
         return $response;

--- a/tests/Unit/CorrelationIdMiddlewareTest.php
+++ b/tests/Unit/CorrelationIdMiddlewareTest.php
@@ -14,7 +14,6 @@ class CorrelationIdMiddlewareTest extends TestCase
         $request = new Request();
 
         (new CorrelationIdMiddleware())->handle($request, function ($request) {
-
             $this->assertTrue($request->headers->has('Correlation-ID'));
             $this->assertEquals($request->getUniqueId(), $request->header('Correlation-ID'));
 

--- a/tests/Unit/CorrelationIdMiddlewareTest.php
+++ b/tests/Unit/CorrelationIdMiddlewareTest.php
@@ -9,17 +9,28 @@ use Illuminate\Http\Response;
 
 class CorrelationIdMiddlewareTest extends TestCase
 {
-    public function test_adds_response_header(): void
+    public function test_adds_request_header(): void
     {
-        $this->assertEquals('Correlation-ID', config('request-logger.header'));
-
         $request = new Request();
 
-        $response1 = (new CorrelationIdMiddleware())->handle($request, function ($request) {
+        (new CorrelationIdMiddleware())->handle($request, function ($request) {
+
+            $this->assertTrue($request->headers->has('Correlation-ID'));
+            $this->assertEquals($request, $request->header('Correlation-ID'));
+
+            return new Response();
+        });
+    }
+
+    public function test_adds_response_header(): void
+    {
+        $request = new Request();
+
+        $response = (new CorrelationIdMiddleware())->handle($request, function ($request) {
             return new Response();
         });
 
-        $this->assertTrue($response1->headers->has('Correlation-ID'));
-        $this->assertEquals($request->getUniqueId(), $response1->headers->get('Correlation-ID'));
+        $this->assertTrue($response->headers->has('Correlation-ID'));
+        $this->assertEquals($response, $request->header('Correlation-ID'));
     }
 }

--- a/tests/Unit/CorrelationIdMiddlewareTest.php
+++ b/tests/Unit/CorrelationIdMiddlewareTest.php
@@ -16,7 +16,7 @@ class CorrelationIdMiddlewareTest extends TestCase
         (new CorrelationIdMiddleware())->handle($request, function ($request) {
 
             $this->assertTrue($request->headers->has('Correlation-ID'));
-            $this->assertEquals($request, $request->header('Correlation-ID'));
+            $this->assertEquals($request->getUniqueId(), $request->header('Correlation-ID'));
 
             return new Response();
         });
@@ -31,6 +31,6 @@ class CorrelationIdMiddlewareTest extends TestCase
         });
 
         $this->assertTrue($response->headers->has('Correlation-ID'));
-        $this->assertEquals($response, $request->header('Correlation-ID'));
+        $this->assertEquals($request->getUniqueId(), $request->header('Correlation-ID'));
     }
 }

--- a/tests/Unit/CorrelationIdMiddlewareTest.php
+++ b/tests/Unit/CorrelationIdMiddlewareTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bilfeldt\RequestLogger\Tests\Unit;
+
+use Bilfeldt\RequestLogger\Middleware\CorrelationIdMiddleware;
+use Bilfeldt\RequestLogger\Tests\TestCase;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class CorrelationIdMiddlewareTest extends TestCase
+{
+    public function test_adds_response_header(): void
+    {
+        $this->assertEquals('Correlation-ID', config('request-logger.header'));
+
+        $request = new Request();
+
+        $response1 = (new CorrelationIdMiddleware())->handle($request, function ($request) {
+            return new Response();
+        });
+
+        $this->assertTrue($response1->headers->has('Correlation-ID'));
+        $this->assertEquals($request->getUniqueId(), $response1->headers->get('Correlation-ID'));
+    }
+}


### PR DESCRIPTION
Add a new middleware that can be used to add the requests unique id as a request and response header `Correlation-ID`