### PR TITLE
Configurable user model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ No breaking changes. The only changes are to the development dependencies used f
 
 ## Changes
 
+- Add config for which model to use in the `RequestLog` models `user()` relationship
+
 ### 3.2.0
 
 - Add Laravel 11 compatibility

--- a/config/request-logger.php
+++ b/config/request-logger.php
@@ -87,6 +87,8 @@ return [
     | This is the model used for user relationships.
     | You can set a custom user model for relationships.
     |
+    | Leaving this empty will use the model from the 'users' auth provider.
+    |
     */
-    'user_model' => env('REQUEST_LOGGER_USER_MODEL', config('auth.providers.users.model')),
+    'user_model' => env('REQUEST_LOGGER_USER_MODEL'),
 ];

--- a/config/request-logger.php
+++ b/config/request-logger.php
@@ -78,4 +78,14 @@ return [
         'Authorization',
         'filter.search',
     ],
-];
+
+    /*
+    |--------------------------------------------------------------------------
+    | User Model
+    |--------------------------------------------------------------------------
+    |
+    | This is the model used for user relationships.
+    | You can set a custom user model for relationships.
+    |
+    */
+    'user_model' => env('REQUEST_LOGGER_USER_MODEL', config('auth.providers.users.model')),

--- a/src/Models/RequestLog.php
+++ b/src/Models/RequestLog.php
@@ -69,7 +69,7 @@ class RequestLog extends Model implements RequestLoggerInterface
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo(config('request-logger.user_model'));
+        return $this->belongsTo(config('request-logger.user_model') ?? config('auth.providers.users.model'));
     }
 
     public function team(): BelongsTo

--- a/src/Models/RequestLog.php
+++ b/src/Models/RequestLog.php
@@ -69,7 +69,7 @@ class RequestLog extends Model implements RequestLoggerInterface
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo(config('auth.providers.users.model'));
+        return $this->belongsTo(config('request-logger.user_model'));
     }
 
     public function team(): BelongsTo


### PR DESCRIPTION
# Description

Making user model configurable

## Does this close any currently open issues?

No. But the configurable model is needed to make code compatible with ldaprecord. LdapRecord, when using database configuration, the user relation is from auth.providers.users.**database**.model and not from auth.providers.users.model. Therefore, both packages won't work together. As of now, a custom model is required.