### PR TITLE
Security | Also mask lowercased variant of filter params

### DIFF
--- a/src/Models/RequestLog.php
+++ b/src/Models/RequestLog.php
@@ -180,18 +180,7 @@ class RequestLog extends Model implements RequestLoggerInterface
 
     protected function replaceParameters(array $array, array $hidden, string $value = '*'): array
     {
-        foreach ($hidden as $param) {
-            foreach ([$param, mb_strtolower($param)] as $key) {
-                if ($origValue = Arr::get($array, $key)) {
-                    Arr::set($array, $key, strlen($value) === 1
-                        ? str_repeat($value, mb_strlen($origValue))
-                        : $value
-                    );
-                }
-            }
-        }
-
-        return $array;
+        return Arr::maskCaseInsensitive($array, $hidden, $value);
     }
 
     protected function truncateToLength(?string $string, int $length = 255): ?string

--- a/src/Models/RequestLog.php
+++ b/src/Models/RequestLog.php
@@ -178,12 +178,15 @@ class RequestLog extends Model implements RequestLoggerInterface
         return $this->replaceParameters($data, RequestLoggerFacade::getFilters());
     }
 
-    protected function replaceParameters(array $array, array $filters, string $maskChar = '*'): array
+    protected function replaceParameters(array $array, array $hidden, string $value = '*'): array
     {
-        foreach ($filters as $param) {
+        foreach ($hidden as $param) {
             foreach ([$param, mb_strtolower($param)] as $key) {
-                if ($value = Arr::get($array, $key)) {
-                    Arr::set($array, $key, str_repeat($maskChar, mb_strlen($value)));
+                if ($origValue = Arr::get($array, $key)) {
+                    Arr::set($array, $key, strlen($value) === 1
+                        ? str_repeat($value, mb_strlen($origValue))
+                        : $value
+                    );
                 }
             }
         }

--- a/src/Models/RequestLog.php
+++ b/src/Models/RequestLog.php
@@ -178,11 +178,13 @@ class RequestLog extends Model implements RequestLoggerInterface
         return $this->replaceParameters($data, RequestLoggerFacade::getFilters());
     }
 
-    protected function replaceParameters(array $array, array $hidden, string $value = '********'): array
+    protected function replaceParameters(array $array, array $filters, string $maskChar = '*'): array
     {
-        foreach ($hidden as $parameter) {
-            if (Arr::get($array, $parameter)) {
-                Arr::set($array, $parameter, '********');
+        foreach ($filters as $param) {
+            foreach ([$param, mb_strtolower($param)] as $key) {
+                if ($value = Arr::get($array, $key)) {
+                    Arr::set($array, $key, str_repeat($maskChar, mb_strlen($value)));
+                }
             }
         }
 

--- a/src/RequestLoggerServiceProvider.php
+++ b/src/RequestLoggerServiceProvider.php
@@ -8,8 +8,10 @@ use Bilfeldt\RequestLogger\Middleware\LogRequestMiddleware;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class RequestLoggerServiceProvider extends ServiceProvider
 {
@@ -72,6 +74,41 @@ class RequestLoggerServiceProvider extends ServiceProvider
             $this->attributes->set('log', $loggers);
 
             return $this;
+        });
+
+        /**
+         * Mask an array's values by keys, supporting nested keys with case-insensitive matching.
+         * If the provided mask is a single character, it will be repeated to match the original value's length.
+         */
+        Arr::macro('maskCaseInsensitive', function (array $array, array $keys, string $character = '*'): array {
+            $lowerKeys = array_map('mb_strtolower', $keys);
+
+            // Iterate over the flattened array keys
+            foreach (array_keys(Arr::dot($array)) as $dottedKey) {
+                $lowerDottedKey = mb_strtolower($dottedKey);
+                // Try to match the lowercased dotted key or its parent key, so we can also mask nested arrays.
+                $matchedKey = in_array($lowerDottedKey, $lowerKeys, true)
+                    ? $dottedKey
+                    : (in_array(Str::beforeLast($lowerDottedKey, '.'), $lowerKeys, true)
+                        ? Str::beforeLast($dottedKey, '.')
+                        : null);
+
+                if ($matchedKey !== null) {
+                    $value = Arr::get($array, $matchedKey);
+                    $masked = match (true) {
+                        mb_strlen($character) > 1 => $character,
+                        ! filled($value) => $value,
+                        is_string($value) || is_int($value) => Str::mask((string) $value, $character, 0),
+                        default => str_repeat($character, 8), // default mask: '********'
+                    };
+
+                    if ($value !== $masked && Arr::has($array, $matchedKey)) {
+                        Arr::set($array, $matchedKey, $masked);
+                    }
+                }
+            }
+
+            return $array;
         });
     }
 }


### PR DESCRIPTION
The current set of default `request-logger.filters` in `config/request-logger.php` is quite misleading:

```php
    'filters' => [
        'password',
        'password_confirm',
        'apikey',
        'api_token',
        'Authorization', // 💥
        'filter.search',
    ],
```

You could assume that `Request` header keys are Pascal-Cased, as the sample filters contain `Authorization`. This is widely used, even though the standards say they are case insensitive and should be lowercased.

In my case, this led to a security issue, as none of my webhook's `authorization` headers were masked in `RequestLog` model's `headers` attribute. The current implementation of `RequestLog::replaceParameters()` is case-sensitive, but the `Request` headers were actually lowercased. `Arr::get()` and `Arr::set()` are also case-sensitive.

As a workaround, I am now search-replacing both variants, the original filter key plus its lowercased version. So we can safely leave `Authorization` in the default config.


In addition, this PR now masks the filtered values by the same length of asterisks (BEFORE: fixed-length `********`), for improved debugging.