### PR TITLE
Add configurable database connection for request logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ No breaking changes. The only changes are to the development dependencies used f
 
 ## Changes
 
+### Unreleased
+
+- Add `request-logger.connection` config option (controlled by the `REQUEST_LOGGER_DB_CONNECTION` env var) so the `RequestLog` model and its migration can be stored in a dedicated database connection separate from the main application data.
+
 ### 3.8.0 - 2026-03-06
 
 - Add Laravel 13 support

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ Note that the default `RequestLog` model setup by this package will not be disco
 
 ## Notes and advises
 
+### Storing logs in a dedicated database
+
+The `RequestLog` model uses the application's default database connection. To store logs in a separate database (e.g. a dedicated logging database to keep them out of your main application data), set the `REQUEST_LOGGER_DB_CONNECTION` environment variable to a connection name configured in `config/database.php`:
+
+```dotenv
+REQUEST_LOGGER_DB_CONNECTION=logging
+```
+
+When using a connection that points at a different database than the `users` table, drop the `user_id` foreign key constraint in the migration — cross-database foreign keys cannot be enforced. Replace `foreignId('user_id')->constrained()->cascadeOnDelete()` with `unsignedBigInteger('user_id')->nullable()->index()`.
+
 ### Proxies and load balancers
 
 When using proxies and/or load balancers then the IP address of the proxy/load balancer must be listed as a [Trusted Proxy](https://laravel.com/docs/8.x/requests#configuring-trusted-proxies) for the users IP address to be correctly logged as the IP of the proxy itself will be logged otherwise.

--- a/config/request-logger.php
+++ b/config/request-logger.php
@@ -36,6 +36,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | The database connection that should be used by the model driver. When
+    | left empty (or null) the default connection from `config/database.php`
+    | will be used. This makes it possible to store request logs in a
+    | dedicated logging database, separate from the main application data.
+    |
+    */
+    'connection' => env('REQUEST_LOGGER_DB_CONNECTION'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Driver
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/create_request_logs_table.php.stub
+++ b/database/migrations/create_request_logs_table.php.stub
@@ -6,14 +6,19 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    public function getConnection(): ?string
+    {
+        return config('request-logger.connection') ?: parent::getConnection();
+    }
+
     public function up()
     {
-        Schema::create('request_logs', function (Blueprint $table) {
+        Schema::connection($this->getConnection())->create('request_logs', function (Blueprint $table) {
             $table->id();
             $table->uuid('uuid')->nullable()->unique();
             $table->string('correlation_id')->nullable(); // This is not unique if subsequent (queued) requests are logged
             $table->string('client_request_id')->nullable();
-            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete(); // Drop the FK constraint (use unsignedBigInteger) if 'request-logger.connection' points at a different database than the users table
             $table->unsignedBigInteger('team_id')->nullable(); // Can be changed to the following if your application uses teams: $table->foreignId('team_id')->nullable()->constrained();
             $table->ipAddress('ip')->nullable();
             $table->string('session')->nullable();
@@ -41,6 +46,6 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('request_logs');
+        Schema::connection($this->getConnection())->dropIfExists('request_logs');
     }
 };

--- a/src/Models/RequestLog.php
+++ b/src/Models/RequestLog.php
@@ -51,6 +51,11 @@ class RequestLog extends Model implements RequestLoggerInterface
         'response_body' => 'json',
     ];
 
+    public function getConnectionName(): ?string
+    {
+        return config('request-logger.connection') ?: parent::getConnectionName();
+    }
+
     //======================================================================
     // ACCESSORS
     //======================================================================


### PR DESCRIPTION
## Summary

- Adds a new `request-logger.connection` config option (controlled via the `REQUEST_LOGGER_DB_CONNECTION` env var) so the `RequestLog` model and its migration can be stored on a dedicated database connection, separate from the main application data.
- `RequestLog::getConnectionName()` reads from the new config, falling back to the model's default behaviour when empty.
- The published migration stub now uses `Schema::connection(...)` and overrides `getConnection()` the same way, so the table is created on the configured connection.
- README gains a short "Storing logs in a dedicated database" section noting that the `user_id` foreign key constraint should be dropped if the logging connection points at a different database than the `users` table (cross-database FKs can't be enforced).

## Motivation

In larger applications, request logs grow fast and are operational data — not user-facing business data. Letting them live on a separate logging connection keeps them out of backups/replicas of the main database and avoids contention. This is the same pattern Pulse, Telescope and Horizon already use.

Fully backwards compatible: when `REQUEST_LOGGER_DB_CONNECTION` is unset (or empty), behaviour is unchanged.

## Test plan

- [x] Existing test suite still passes (`composer test`)
- [ ] Verify in a host app that setting `REQUEST_LOGGER_DB_CONNECTION=logging` causes `RequestLog` writes/reads to hit the `logging` connection
- [ ] Verify that with the env var unset, behaviour is identical to before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)