### PR TITLE
Match HTTP header filters case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ No breaking changes. The only changes are to the development dependencies used f
 ### Unreleased
 
 - Add `request-logger.connection` config option (controlled by the `REQUEST_LOGGER_DB_CONNECTION` env var) so the `RequestLog` model and its migration can be stored in a dedicated database connection separate from the main application data.
+- Fix: HTTP header filters are now matched case-insensitively. The default `Authorization` filter never matched because Symfony's `HeaderBag` lowercases header names while `Arr::get` is case-sensitive — Bearer tokens were silently written to the log. Header filtering now lowercases both sides; payload filtering remains case-sensitive (JSON keys are case-sensitive per spec).
 
 ### 3.8.0 - 2026-03-06
 

--- a/config/request-logger.php
+++ b/config/request-logger.php
@@ -88,7 +88,7 @@ return [
         'password_confirm',
         'apikey',
         'api_token',
-        'Authorization',
+        'authorization', // HTTP header — filter matching against headers is case-insensitive
         'filter.search',
     ],
 

--- a/src/Models/RequestLog.php
+++ b/src/Models/RequestLog.php
@@ -111,9 +111,9 @@ class RequestLog extends Model implements RequestLoggerInterface
         $model->route = $this->truncateToLength(optional($request->route())->getName() ?? optional($request->route())->uri()); // Note that $request->route()->uri() does not replace the placeholders while $request->getRequestUri() replaces the placeholders
         $model->path = $this->truncateToLength($request->path());
         $model->status = $response->getStatusCode();
-        $model->headers = $this->getFiltered($request->headers->all()) ?: null;
+        $model->headers = $this->getFilteredHeaders($request->headers->all()) ?: null;
         $model->payload = $this->getFiltered($request->input()) ?: null;
-        $model->response_headers = $this->getFiltered($response->headers->all()) ?: null;
+        $model->response_headers = $this->getFilteredHeaders($response->headers->all()) ?: null;
         $model->response_body = $this->getLoggableResponseContent($response);
         $model->duration = $duration;
         $model->memory = round($memory / 1024 / 1024, 2); // [MB]
@@ -181,6 +181,19 @@ class RequestLog extends Model implements RequestLoggerInterface
     protected function getFiltered(array $data)
     {
         return $this->replaceParameters($data, RequestLoggerFacade::getFilters());
+    }
+
+    /**
+     * Filter HTTP headers. HTTP header names are case-insensitive per RFC 7230
+     * and Symfony's HeaderBag always lowercases the keys, so the filter tokens
+     * are lowercased here to make matching reliable regardless of the casing
+     * used in the configured filter list.
+     */
+    protected function getFilteredHeaders(array $headers)
+    {
+        $filters = array_map('strtolower', RequestLoggerFacade::getFilters());
+
+        return $this->replaceParameters($headers, $filters);
     }
 
     protected function replaceParameters(array $array, array $hidden, string $value = '********'): array

--- a/tests/Feature/RequestLogFilteringTest.php
+++ b/tests/Feature/RequestLogFilteringTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Bilfeldt\RequestLogger\Tests\Feature;
+
+use Bilfeldt\RequestLogger\Models\RequestLog;
+use Bilfeldt\RequestLogger\Tests\TestCase;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class RequestLogFilteringTest extends TestCase
+{
+    public function test_authorization_header_is_filtered_regardless_of_filter_casing()
+    {
+        config()->set('request-logger.filters', ['Authorization']);
+
+        $request = Request::create('/orders', 'POST');
+        $request->headers->set('Authorization', 'Bearer super-secret-token');
+
+        (new RequestLog())->log($request, new Response('{}', 200, ['Content-Type' => 'application/json']));
+
+        $log = RequestLog::query()->latest('id')->first();
+
+        $this->assertNotNull($log->headers);
+        $this->assertSame('********', $log->headers['authorization']);
+        $this->assertStringNotContainsString('super-secret-token', json_encode($log->headers));
+    }
+
+    public function test_payload_filtering_remains_case_sensitive()
+    {
+        config()->set('request-logger.filters', ['password']);
+
+        $request = Request::create('/login', 'POST', [
+            'password' => 'secret',
+            'Password' => 'kept-as-is',
+        ]);
+
+        (new RequestLog())->log($request, new Response('{}', 200, ['Content-Type' => 'application/json']));
+
+        $log = RequestLog::query()->latest('id')->first();
+
+        $this->assertSame('********', $log->payload['password']);
+        $this->assertSame('kept-as-is', $log->payload['Password']);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Bilfeldt\RequestLogger\Tests;
 
+use Bilfeldt\CorrelationId\CorrelationIdServiceProvider;
 use Bilfeldt\RequestLogger\RequestLoggerServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
@@ -20,6 +21,7 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
+            CorrelationIdServiceProvider::class,
             RequestLoggerServiceProvider::class,
         ];
     }


### PR DESCRIPTION
## Summary

- The default `Authorization` filter never actually masked anything. Symfony's `HeaderBag::all()` lowercases header names (`authorization`), while `Arr::get` / `Arr::set` match keys case-sensitively — so the filter token `Authorization` looked up a key that didn't exist and Bearer tokens were written to the log in plaintext.
- New `getFilteredHeaders()` lowercases the filter tokens before delegating to `replaceParameters()`, then matches against header keys that are already lowercase. Used for both `headers` and `response_headers`.
- `getFiltered()` (payload + response body) is unchanged — JSON keys are case-sensitive per spec, so payload filtering stays exact-match.
- Default filter list updated: `Authorization` → `authorization`, with a comment explaining why casing doesn't matter for header tokens.

## Test plan

- [x] New `tests/Feature/RequestLogFilteringTest.php`:
  - Asserts that a filter configured as `Authorization` masks an `Authorization: Bearer …` request header.
  - Asserts that payload filtering remains case-sensitive (`password` is masked, `Password` is not).
- [x] Existing test suite still passes (`composer test`).

## Notes

- `CorrelationIdServiceProvider` is now booted in the test harness so `RequestLog::log()` can be exercised end-to-end (it calls `$request->getUniqueId()` / `getCorrelationId()`, both of which are macros registered by that provider).
- This is a behaviour change for anyone relying on the broken `Authorization` filter masking *nothing* — but that is by definition not intended behaviour, so it ships as a fix rather than a breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)